### PR TITLE
Fix missing variable - replace with vorpal.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ function connect2network(n, callback){
     if(!body) connect2network(n, callback);
     else{
       n.config = JSON.parse(body).network;
-      self.log(n.config);
+      vorpal.log(n.config);
       callback();
     }
   });


### PR DESCRIPTION
Resolves #18 

Fixes command `connect mainnet` - fails because `self` is not declared for `self.log(n.config);`
@fix - may be worth merging sooner rather than later as the `connect` command currently doesn't work.

Thanks!

**Edit:** The alternative is to take out the log completely - is it necessary for production?