### PR TITLE
Get ledger worker path from relative path

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,11 @@ var async = require('async');
 var vorpal = require('vorpal')();
 var cluster = require('cluster');
 var child_process = require('child_process');
+var Path = require('path');
 
 var ledger = require('ledgerco')
 var LedgerArk = require('./src/LedgerArk.js');
-var ledgerWorker = child_process.fork('./ledger-worker');
+var ledgerWorker = child_process.fork(Path.resolve(__dirname, './ledger-worker'));
 
 var blessed = require('blessed');
 var contrib = require('blessed-contrib');


### PR DESCRIPTION
Resolves an issue when globally installing ark-client (`npm install -g arkecosystem/ark-client#master`). Looks for the ledger-worker file locally from being called, instead of relative to the application.