### PR TITLE
Prevent malformed WIF generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ var networks = {
   }
 };
 
+function isConnected() {
+  return server && connected;
+}
+
 function getNetworkFromNethash(nethash){
   for(var n in networks){
     if(networks[n].nethash == nethash){
@@ -461,7 +465,7 @@ vorpal
   .command('network stats', 'Get stats from network')
   .action(function(args, callback) {
     var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("Please connect to node or network before");
       return callback();
     }
@@ -546,7 +550,7 @@ vorpal
   .command('account status <address>', 'Get account status')
   .action(function(args, callback) {
     var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -595,7 +599,7 @@ vorpal
   .command('account vote <name>', 'Vote for delegate <name>. Remove previous vote if needed')
   .action(function(args, callback) {
     var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -726,7 +730,7 @@ vorpal
   .command('account unvote', 'Remove previous vote')
   .action(function(args, callback) {
     var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -807,7 +811,7 @@ vorpal
   .command('account send <amount> <address>', 'Send <amount> ark to <address>. <amount> format examples: 10, USD10.4, EUR100')
   .action(function(args, callback) {
 		var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -917,7 +921,7 @@ vorpal
   .command('account delegate <username>', 'Register new delegate with <username> ')
   .action(function(args, callback) {
 		var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -977,7 +981,7 @@ vorpal
   .command('account create', 'Generate a new random cold account')
   .action(function(args, callback) {
 		var self = this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before, in order to retrieve necessery information about address prefixing");
       return callback();
     }
@@ -992,7 +996,7 @@ vorpal
   .command('account vanity <string>', 'Generate an address containing lowercased <string> (WARNING you could wait for long)')
   .action(function(args, callback) {
     var self=this;
-    if(!server || !connected){
+    if(!isConnected()){
       self.log("please connect to node or network before, in order to retrieve necessery information about address prefixing");
       return callback();
     }

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ var ledgerWorker = child_process.fork(Path.resolve(__dirname, './ledger-worker')
 var blessed = require('blessed');
 var contrib = require('blessed-contrib');
 
+var connected = false;
 var server;
 var network;
 var arkticker = {};
@@ -372,6 +373,7 @@ vorpal
         self.log("Node: " + server + ", height: " + JSON.parse(body).height);
         self.delimiter('ark '+args.network+'>');
         arkjs.crypto.setNetworkVersion(network.config.version);
+	connected = true;
         callback();
       });
     });
@@ -438,6 +440,7 @@ vorpal
       getFromNode('http://'+server+'/peer/status', function(err, response, body){
         self.log("Node height ", JSON.parse(body).height);
       });
+      connected = true;
       callback();
     });
   });
@@ -450,6 +453,7 @@ vorpal
     self.delimiter('ark>');
     server=null;
     network=null;
+    connected = false;
     callback();
   });
 
@@ -457,7 +461,7 @@ vorpal
   .command('network stats', 'Get stats from network')
   .action(function(args, callback) {
     var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("Please connect to node or network before");
       return callback();
     }
@@ -542,7 +546,7 @@ vorpal
   .command('account status <address>', 'Get account status')
   .action(function(args, callback) {
     var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -591,7 +595,7 @@ vorpal
   .command('account vote <name>', 'Vote for delegate <name>. Remove previous vote if needed')
   .action(function(args, callback) {
     var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -722,7 +726,7 @@ vorpal
   .command('account unvote', 'Remove previous vote')
   .action(function(args, callback) {
     var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -803,7 +807,7 @@ vorpal
   .command('account send <amount> <address>', 'Send <amount> ark to <address>. <amount> format examples: 10, USD10.4, EUR100')
   .action(function(args, callback) {
 		var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -913,7 +917,7 @@ vorpal
   .command('account delegate <username>', 'Register new delegate with <username> ')
   .action(function(args, callback) {
 		var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before");
       return callback();
     }
@@ -973,7 +977,7 @@ vorpal
   .command('account create', 'Generate a new random cold account')
   .action(function(args, callback) {
 		var self = this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before, in order to retrieve necessery information about address prefixing");
       return callback();
     }
@@ -988,7 +992,7 @@ vorpal
   .command('account vanity <string>', 'Generate an address containing lowercased <string> (WARNING you could wait for long)')
   .action(function(args, callback) {
     var self=this;
-    if(!server){
+    if(!server || !connected){
       self.log("please connect to node or network before, in order to retrieve necessery information about address prefixing");
       return callback();
     }


### PR DESCRIPTION
Repo steps:

1. Ensure there is no connection to the Internet or at least to the various network peers.
2. Attempt to connect to mainnet
  a. the console will scroll error messages.  This will happen very fast if no network connection is present.  If there is a connection to the Internet but the Ark IPs are blocked (like by a corporate firewall) then reconnect messages will scroll slowly.
3. Press CTRL+C, twice to exit the looping command and return to the ark> prompt.
4. Type 'account create' to create an account.
5. Since there is not a fully formed connection to a network, this should not be allowed, but it is.
6. An account will be generated, but with an invalid WIF. 
  a.  Repeating this procedure with a valid connect to mainnet generates a valid WIF.


This patch adds an additional flag to track when the connection has become fully formed since the whole process is async.  Another approach could be to only set the global server variable when the connection is fully formed.  This change would require much more modification to the code and more regression testing since it touches more code paths.

Note:  Javascript is not my first language so I do not know how thread safety (e.g. volatile bool? atomic<bool>?, etc..) plays into this.

Here is a screenshot of the bug:
![image](https://user-images.githubusercontent.com/18743679/40031857-4d784baa-57b7-11e8-84e0-506c68cf95d9.png)

