### PR TITLE
Fix: issue 25 - Crash if trying to send a transaction from a new account 

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,9 +151,7 @@ function postTransaction(container, transaction, cb){
 
   let senderAddress = arkjs.crypto.getAddress(transaction.senderPublicKey);
   getFromNode('http://' + server + '/api/accounts?address=' + senderAddress, function(err, response, body){
-    if(!body) {
-      performPost();
-    } else {
+    if(body) {
       body = JSON.parse(body);
       if (body.account.secondSignature) {
         container.prompt({
@@ -165,15 +163,15 @@ function postTransaction(container, transaction, cb){
             var secondKeys = arkjs.crypto.getKeys(result.passphrase);
             arkjs.crypto.secondSign(transaction, secondKeys);
             transaction.id = arkjs.crypto.getId(transaction);
-            performPost();
+            
           } else {
             vorpal.log('No second passphrase given. Trying without.');
-            performPost();
+            
           }
         });
-      } else {
-        performPost();
+
       }
+      performPost(); 
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -150,29 +150,35 @@ function postTransaction(container, transaction, cb){
   };
 
   let senderAddress = arkjs.crypto.getAddress(transaction.senderPublicKey);
-  getFromNode('http://' + server + '/api/accounts?address=' + senderAddress, function(err, response, body){
-    if(body) {
-      body = JSON.parse(body);
-      if (body.account.secondSignature) {
-        container.prompt({
-          type: 'password',
-          name: 'passphrase',
-          message: 'Second passphrase: ',
-        }, function(result) {
-          if (result.passphrase) {
-            var secondKeys = arkjs.crypto.getKeys(result.passphrase);
-            arkjs.crypto.secondSign(transaction, secondKeys);
-            transaction.id = arkjs.crypto.getId(transaction);
-            
-          } else {
-            vorpal.log('No second passphrase given. Trying without.');
-            
-          }
-        });
+  getFromNode('http://' + server + '/api/accounts?address=' + senderAddress, 
+    function(err, response, body){
+    // handle the potential error
+    if(err) {
+      vorpal.log('Someting went wrong: '+err);
 
-      }
-      performPost(); 
-    }
+    } else { 
+      if(body) {
+        body = JSON.parse(body);
+        if (body.account.secondSignature) {
+          container.prompt({
+            type: 'password',
+            name: 'passphrase',
+            message: 'Second passphrase: ',
+          }, function(result) {
+            if (result.passphrase) {
+              var secondKeys = arkjs.crypto.getKeys(result.passphrase);
+              arkjs.crypto.secondSign(transaction, secondKeys);
+              transaction.id = arkjs.crypto.getId(transaction);
+            
+            } else {
+              vorpal.log('No second passphrase given. Trying without.');
+            
+            }
+          });
+        }
+        performPost(); 
+      } // if(body)
+    } // if(err)  
   });
 }
 


### PR DESCRIPTION
When a new account is created it is not directly know at all the nodes. When trying to send to/from this account using the postTransaction() method internally the getFromNode() method returns a failure status in the body of the response. There is no check for this status and subsequently the app will crash. This bug is described in issue #25.

I have fixed this bug by adding the necessary checks and error handling to the postTransaction() method. 

_I have spotted some other bugs in this file and will submit separate PRs for them later._