### PR TITLE
Corrected command structure

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -39,6 +39,8 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
+  .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
+  .option('-s, --smartbridge <smartbridge>', 'Enter a string for the SmartBridge.')
   .action(async (amount, recepient, cmd) => wallet.send(amount, recepient, cmd));
   
 commander
@@ -48,6 +50,7 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
+  .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
   .action(async (delegate,cmd) => wallet.vote(delegate, cmd));
   
 commander
@@ -57,6 +60,7 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
+  .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
   .action(async (username,cmd) => wallet.delegate(username, cmd));
   
 commander
@@ -75,6 +79,7 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
+  .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
   .action(async (message, cmd) => message.sign(message, cmd));
   
 commander

--- a/bin/cli
+++ b/bin/cli
@@ -1,29 +1,95 @@
 #!/usr/bin/env node
 
-const commander = require('commander')
+const commander = require('commander');
 
-const { message, network, wallet } = require('../lib/commands')
+const { message, wallet } = require('../lib/commands');
 
 commander
-  .version('1.0.0')
-  .description('CLI for the ARK Blockchain')
-  .command('wallet create').action(() => wallet.create())
-  .command('wallet delegate <username>').action(() => wallet.delegate())
-  .command('wallet send <amount> <recipient>').action(() => wallet.send())
-  .command('wallet stats').action(() => wallet.stats())
-  .command('wallet status <address>').action(() => wallet.status())
-  .command('wallet vanity <string>').action(() => wallet.vanity())
-  .command('wallet vote <username>').action(() => wallet.vote())
-  .command('message sign <message>').action(() => message.sign())
-  .command('message verify <message> <publickey>').action(() => message.verify())
-  .command('connect <network>').action(() => network.connect())
-  .command('connect node <node>').action(() => network.connectNode())
-  .command('disconnect').action(() => network.disconnect())
+  .version('1.0.0');
+  
+commander
+  .command('wallet <address>')
+  .description('Get status for wallet with <address>.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (address, cmd) => wallet.status(address, cmd));
+ 
+commander
+  .command('create')
+  .description('Create a new wallet.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .option('--vanity <string>', 'Create a vanity wallet that contains <string>.')
+  .action(async (cmd) => {
+    if(cmd.vanity) {
+      await wallet.vanity(cmd.vanity);
+      return;
+    }
+    await wallet.create();
+  });
+  
+commander
+  .command('send <amount> <recepient>')
+  .description('Send <amount> to <recepient>.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (amount, recepient, cmd) => wallet.send(amount, recepient, cmd));
+  
+commander
+  .command('vote <delegate>')
+  .description('Vote for <delegate>.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')  
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (delegate,cmd) => wallet.vote(delegate, cmd));
+  
+commander
+  .command('delegate <username>')
+  .description('Register as delegate with <username>.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')  
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (username,cmd) => wallet.delegate(username, cmd));
+  
+commander
+  .command('stats')
+  .description('Get the network stats.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')  
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (cmd) => wallet.delegate(cmd));
+  
+commander
+  .command('sign <message>')
+  .description('Sign <message>.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')  
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (message, cmd) => message.sign(message, cmd));
+  
+commander
+  .command('verify <message> <publickey>')
+  .description('Verify <message> with <publickey>.')
+  .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
+  .option('-c, --node <node>', 'Connect directly to node <node>.')  
+  .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
+  .option('-v, --verbose', 'Show verbose logging.')
+  .action(async (message, publickey, cmd) => message.verify(message, publickey, cmd));
 
 if (!process.argv.slice(2).length) {
-  commander.outputHelp()
+  commander.outputHelp();
 
-  process.exit()
+  process.exit();
 }
 
 commander.parse(process.argv)

--- a/bin/cli
+++ b/bin/cli
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const commander = require('commander');
+const commander = require('commander')
 
-const { message, wallet } = require('../lib/commands');
+const { Message, Wallet } = require('../lib/commands')
 
 commander
-  .version('1.0.0');
+  .version('1.0.0')
   
 commander
   .command('wallet <address>')
@@ -14,7 +14,7 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
-  .action(async (address, cmd) => wallet.status(address, cmd));
+  .action(async (address, cmd) => Wallet.status(address, cmd))
  
 commander
   .command('create')
@@ -26,11 +26,11 @@ commander
   .option('--vanity <string>', 'Create a vanity wallet that contains <string>.')
   .action(async (cmd) => {
     if(cmd.vanity) {
-      await wallet.vanity(cmd.vanity);
-      return;
+      await Wallet.vanity(cmd.vanity)
+      return
     }
-    await wallet.create();
-  });
+    await Wallet.create()
+  })
   
 commander
   .command('send <amount> <recepient>')
@@ -41,7 +41,7 @@ commander
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
   .option('-s, --smartbridge <smartbridge>', 'Enter a string for the SmartBridge.')
-  .action(async (amount, recepient, cmd) => wallet.send(amount, recepient, cmd));
+  .action(async (amount, recepient, cmd) => Wallet.send(amount, recepient, cmd))
   
 commander
   .command('vote <delegate>')
@@ -51,7 +51,7 @@ commander
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
-  .action(async (delegate,cmd) => wallet.vote(delegate, cmd));
+  .action(async (delegate,cmd) => Wallet.vote(delegate, cmd))
   
 commander
   .command('delegate <username>')
@@ -61,7 +61,7 @@ commander
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
-  .action(async (username,cmd) => wallet.delegate(username, cmd));
+  .action(async (username,cmd) => Wallet.delegate(username, cmd))
   
 commander
   .command('stats')
@@ -70,7 +70,7 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
-  .action(async (cmd) => wallet.delegate(cmd));
+  .action(async (cmd) => Wallet.delegate(cmd))
   
 commander
   .command('sign <message>')
@@ -80,7 +80,7 @@ commander
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
-  .action(async (message, cmd) => message.sign(message, cmd));
+  .action(async (message, cmd) => Message.sign(message, cmd))
   
 commander
   .command('verify <message> <publickey>')
@@ -89,12 +89,12 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
-  .action(async (message, publickey, cmd) => message.verify(message, publickey, cmd));
+  .action(async (message, publickey, cmd) => Message.verify(message, publickey, cmd))
 
 if (!process.argv.slice(2).length) {
-  commander.outputHelp();
+  commander.outputHelp()
 
-  process.exit();
+  process.exit()
 }
 
 commander.parse(process.argv)

--- a/bin/cli
+++ b/bin/cli
@@ -2,7 +2,7 @@
 
 const commander = require('commander')
 
-const { Message, Wallet } = require('../lib/commands')
+const { message, wallet } = require('../lib/commands')
 
 commander
   .version('1.0.0')
@@ -14,7 +14,7 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
-  .action(async (address, cmd) => Wallet.status(address, cmd))
+  .action(async (address, cmd) => wallet.status(address, cmd))
  
 commander
   .command('create')
@@ -26,10 +26,10 @@ commander
   .option('--vanity <string>', 'Create a vanity wallet that contains <string>.')
   .action(async (cmd) => {
     if(cmd.vanity) {
-      await Wallet.vanity(cmd.vanity)
+      await wallet.vanity(cmd.vanity)
       return
     }
-    await Wallet.create()
+    await wallet.create()
   })
   
 commander
@@ -41,7 +41,7 @@ commander
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
   .option('-s, --smartbridge <smartbridge>', 'Enter a string for the SmartBridge.')
-  .action(async (amount, recepient, cmd) => Wallet.send(amount, recepient, cmd))
+  .action(async (amount, recepient, cmd) => wallet.send(amount, recepient, cmd))
   
 commander
   .command('vote <delegate>')
@@ -51,7 +51,7 @@ commander
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
-  .action(async (delegate,cmd) => Wallet.vote(delegate, cmd))
+  .action(async (delegate,cmd) => wallet.vote(delegate, cmd))
   
 commander
   .command('delegate <username>')
@@ -61,7 +61,7 @@ commander
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
-  .action(async (username,cmd) => Wallet.delegate(username, cmd))
+  .action(async (username,cmd) => wallet.delegate(username, cmd))
   
 commander
   .command('stats')
@@ -70,26 +70,26 @@ commander
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
-  .action(async (cmd) => Wallet.delegate(cmd))
+  .action(async (cmd) => wallet.delegate(cmd))
   
 commander
-  .command('sign <message>')
-  .description('Sign <message>.')
+  .command('sign <msg>')
+  .description('Sign message <msg>.')
   .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
   .option('-p, --passphrase <passphrase>', 'Enter your passphrase, if you do not enter e passphrase you will be prompted for it.')
-  .action(async (message, cmd) => Message.sign(message, cmd))
+  .action(async (msg, cmd) => message.sign(msg, cmd))
   
 commander
-  .command('verify <message> <publickey>')
-  .description('Verify <message> with <publickey>.')
+  .command('verify <msg> <publickey>')
+  .description('Verify message <msg> with <publickey>.')
   .option('-n, --network <network>', 'Connect to network: [mainnet|devnet]', 'mainnet')
   .option('-c, --node <node>', 'Connect directly to node <node>.')  
   .option('-f, --format <format>', 'Specify how to format the output [json|table]', 'json')
   .option('-v, --verbose', 'Show verbose logging.')
-  .action(async (message, publickey, cmd) => Message.verify(message, publickey, cmd))
+  .action(async (msg, publickey, cmd) => message.verify(msg, publickey, cmd))
 
 if (!process.argv.slice(2).length) {
   commander.outputHelp()

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  Message: {
+  message: {
     sign: require('./message/sign'),
     verify: require('./message/verify')
   },
@@ -8,7 +8,7 @@ module.exports = {
     connectNode: require('./network/connect-node'),
     disconnect: require('./network/disconnect')
   }, */
-  Wallet: {
+  wallet: {
     create: require('./wallet/create'),
     delegate: require('./wallet/delegate'),
     send: require('./wallet/send'),

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,14 +1,14 @@
 module.exports = {
-  message: {
+  Message: {
     sign: require('./message/sign'),
     verify: require('./message/verify')
   },
-  network: {
+  /* network: {
     connect: require('./network/connect'),
     connectNode: require('./network/connect-node'),
     disconnect: require('./network/disconnect')
-  },
-  wallet: {
+  }, */
+  Wallet: {
     create: require('./wallet/create'),
     delegate: require('./wallet/delegate'),
     send: require('./wallet/send'),


### PR DESCRIPTION
Commander works with 'single word commands'that may or may not have options. The exisiting structure uses 'double word'commands like 'wallet create' and 'wallet status'.
Both of these are read as 'wallet' by the commander interpreter and thus will not work.

Also each command needs to connect to a network/node in it's method: object status isn't retained between commands and the idea of a cli is that it also can be executed from a script
(e.g. "cli send 1.0 DMPZeuab5Jz66H6ydCWtSEboRyEjFnyx5T --network devnet --pass passphrase").

Lastly I have specified output options (JSON object, or table) and added the option to verbose show logs.
Both options are making execution by scripts easier, JSON can be processed automatically.