### PR TITLE
feat: Implements cli wallet <address> method to show the wallet status

### DIFF
--- a/lib/commands/wallet/status.js
+++ b/lib/commands/wallet/status.js
@@ -81,7 +81,6 @@ module.exports = async (address, cmd) => {
             ? results.data.error : "Could not retrieve delegate information for this wallet."
           reject(new Error(errorMsg))  
         }
-        console.log(JSON.stringify(results.data))
         if (!results.data.hasOwnProperty('delegates') || !results.data.delegates.length 
           || !results.data.delegates[0].hasOwnProperty('username')) 
         {

--- a/lib/commands/wallet/status.js
+++ b/lib/commands/wallet/status.js
@@ -47,6 +47,9 @@ module.exports = async (address, cmd) => {
     
     if (node) {
       await network.setServer(node)
+      // The network.connect method skips network config when a server and network have been defined already
+      const response = await network.getFromNode('/api/loader/autoconfigure')
+      network.network.config = response.data.network
     }
     await network.connect(net)
     

--- a/lib/commands/wallet/status.js
+++ b/lib/commands/wallet/status.js
@@ -50,20 +50,61 @@ module.exports = async (address, cmd) => {
     }
     await network.connect(net)
     
-    // Retrieve wallet status
-    let response = await network.getFromNode(`/api/accounts?address=${address}`)
-   
-    // Validate response
-    if (!response.data.hasOwnProperty('success') || !response.data.success) {
-      let errorMsg = response.data.hasOwnProperty('error') && response.data.error 
-        ? response.data.error : "Failed to retrieve wallet status from node."
-      throw new Error(errorMsg)  
-    }
+    // Retrieve wallet status && which delegate is voted for (request them parrallelly)
+    let wallet
+    let commands =[]
+    commands.push(new Promise((resolve, reject) => {
+      network.getFromNode(`/api/accounts?address=${address}`)
+      .then((results) => {
+        
+        // Validate response
+        if (!results.data.hasOwnProperty('success') || !results.data.success) {
+          let errorMsg = results.data.hasOwnProperty('error') && results.data.error 
+            ? results.data.error : "Failed to retrieve wallet status from node."
+          reject(new Error(errorMsg))  
+        }
+        wallet = results.data.account
+        resolve()
+      })
+      .catch(error => {
+        reject(error)
+      })
+    }))
+    
+    let delegate
+    commands.push(new Promise((resolve, reject) => {
+      network.getFromNode(`/api/accounts/delegates?address=${address}`)
+      .then((results) => {
+        
+        if (!results.data.hasOwnProperty('success') || !results.data.success) {
+          let errorMsg = results.data.hasOwnProperty('error') && results.data.error 
+            ? results.data.error : "Could not retrieve delegate information for this wallet."
+          reject(new Error(errorMsg))  
+        }
+        console.log(JSON.stringify(results.data))
+        if (!results.data.hasOwnProperty('delegates') || !results.data.delegates.length 
+          || !results.data.delegates[0].hasOwnProperty('username')) 
+        {
+          delegate = "-"
+        }
+        else {
+          delegate = results.data.delegates[0].username
+        }
+        resolve()
+      })
+      .catch(error => {
+        reject(error)
+      })
+    }))
+    await Promise.all(commands)
+    
+    // Add delegate information to output
+    wallet.delegate = delegate;
     
     // Show output
     output.setTitle("ARK Wallet status")
     output.setCurrencySymbol(network.network.config.symbol)
-    output.showOutput(response.data.account)
+    output.showOutput(wallet)
   } 
   catch(error) {
     output.showError(error.message)

--- a/lib/commands/wallet/status.js
+++ b/lib/commands/wallet/status.js
@@ -29,14 +29,14 @@ module.exports = async (address, cmd) => {
   }
   
   try{
+    output.setFormat(format)
+    
     // Validate input
     Joi.validate({ address: address }, schema, (err, value) => {
       if(err) {
         throw new Error("Please enter a valid formatted address.")
       }
     })
-    
-    output.setFormat(format)
     
     // connect to the network
     if (!networks[net]) {
@@ -61,6 +61,8 @@ module.exports = async (address, cmd) => {
     }
     
     // Show output
+    output.setTitle("ARK Wallet status")
+    output.setCurrencySymbol(network.network.config.symbol)
     output.showOutput(response.data.account)
   } 
   catch(error) {

--- a/lib/commands/wallet/status.js
+++ b/lib/commands/wallet/status.js
@@ -1,7 +1,70 @@
 'use strict'
 
-const chalk = require('chalk')
+const Joi = require('joi')
+const network = require('../../services/network')
+const output = require('../../utils/output')
+const networks = require('../../config/networks')
+const schema = {
+  address: Joi.string().length(34).required()
+}
 
-module.exports = () => {
-  console.log(chalk.blue('Hello World!'))
+/**
+ * @dev Get the status for an address from the network
+ * @param {string} address The address to request the status of.
+ * @param {array} cmd A JSON object containing the options for this query (network, node, format, verbose).
+ */
+module.exports = async (address, cmd) => {
+  
+  let net = cmd.network ? cmd.network : 'mainnet'
+  let node = cmd.node ? cmd.node : null
+  let format = cmd.format ? cmd.format : 'json'
+  
+  // Surpres logging if not --verbose
+  if (!cmd.verbose) {
+    network.logger.info=(msg) => {return}
+    network.logger.warn=(msg) => {return}
+    network.logger.error=(err) => {
+      output.showError(err)
+    }
+  }
+  
+  try{
+    // Validate input
+    Joi.validate({ address: address }, schema, (err, value) => {
+      if(err) {
+        throw new Error("Please enter a valid formatted address.")
+      }
+    })
+    
+    output.setFormat(format)
+    
+    // connect to the network
+    if (!networks[net]) {
+      throw new Error(`Unknown network: ${net}`)
+    }
+    
+    await network.setNetwork(net)
+    
+    if (node) {
+      await network.setServer(node)
+    }
+    await network.connect(net)
+    
+    // Retrieve wallet status
+    let response = await network.getFromNode(`/api/accounts?address=${address}`)
+   
+    // Validate response
+    if (!response.data.hasOwnProperty('success') || !response.data.success) {
+      let errorMsg = response.data.hasOwnProperty('error') && response.data.error 
+        ? response.data.error : "Failed to retrieve wallet status from node."
+      throw new Error(errorMsg)  
+    }
+    
+    // Show output
+    output.showOutput(response.data.account)
+  } 
+  catch(error) {
+    output.showError(error.message)
+    process.exitCode = 1
+  }
 }

--- a/lib/config/networks.js
+++ b/lib/config/networks.js
@@ -1,0 +1,16 @@
+module.exports = {
+  devnet: {
+    name: 'devnet',
+    nethash: '578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23',
+    slip44: 1,
+    version: 30,
+    peers: 'https://raw.githubusercontent.com/ArkEcosystem/ARK-Peers/master/devnet.json'
+  },
+  mainnet: {
+    name: 'mainnet',
+    slip44: 111,
+    nethash: '6e84d08bd299ed97c212c886c98a57e36545c8f5d645ca7eeae63a8bd62d8988',
+    version: 23,
+    peers: 'https://raw.githubusercontent.com/ArkEcosystem/ARK-Peers/master/mainnet.json'
+  }
+}

--- a/lib/services/logger.js
+++ b/lib/services/logger.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const pino = require('pino')
+
+const pretty = pino.pretty()
+pretty.pipe(process.stdout)
+
+module.exports = pino({
+  name: 'ark-client',
+  safe: true
+}, pretty)

--- a/lib/services/network.js
+++ b/lib/services/network.js
@@ -1,0 +1,182 @@
+const axios = require('axios')
+const arkjs = require('arkjs')
+const isUrl = require('is-url')
+const isReachable = require('is-reachable')
+const { sample, orderBy } = require('lodash')
+const logger = require('./logger')
+const networks = require('../config/networks')
+
+class Network {
+  async setNetwork (network) {
+    this.network = networks[network]
+
+    await this.__loadRemotePeers()
+
+    arkjs.crypto.setNetworkVersion(this.network.version)
+
+    return this.network
+  }
+
+  async setServer (server) {
+    if (!server) {
+      server = await this.__getRandomPeer()
+    }
+
+    this.server = server
+
+    return this.server
+  }
+
+  async getFromNode (url, params = {}, peer = null) {
+    const nethash = this.network ? this.network.nethash : null
+
+    if (!this.peer && !this.server) {
+      await this.setServer()
+    }
+
+    peer = await this.__selectResponsivePeer(peer || this.server)
+
+    if (!url.startsWith('http')) {
+      url = `http://${peer}${url}`
+    }
+
+    try {
+      logger.info(`Sending request on "${this.network.name}" to "${url}"`)
+
+      return axios.get(url, {
+        params,
+        headers: {
+          nethash,
+          version: '2.0.0',
+          port: 1
+        }
+      })
+    } catch (error) {
+      logger.error(error.message)
+    }
+  }
+
+  async findAvailablePeers () {
+    try {
+      const response = await this.getFromNode('/peer/list')
+
+      let { networkHeight, peers } = this.__filterPeers(response.data.peers)
+
+      if (process.env.NODE_ENV === 'test') {
+        peers = peers.slice(0, 10)
+      }
+
+      let responsivePeers = []
+      for (let i = 0; i < peers.length; i++) {
+        const response = await this.getFromNode(`/peer/status`, {}, peers[i])
+
+        if (Math.abs(response.data.height - networkHeight) <= 10) {
+          responsivePeers.push(peers[i])
+        }
+      }
+
+      this.network.peers = responsivePeers
+    } catch (error) {
+      logger.error(error.message)
+    }
+  }
+
+  async postTransaction (transaction, peer) {
+    const server = peer || this.server
+
+    return axios.post(`http://${server}/peer/transactions`, {
+      transactions: [transaction]
+    }, {
+      headers: {
+        nethash: this.network.nethash,
+        version: '1.0.0',
+        port: 1
+      }
+    })
+  }
+
+  async broadcast (transaction) {
+    const peers = this.network.peers.slice(0, 10)
+
+    for (let i = 0; i < peers.length; i++) {
+      logger.info(`Broadcasting to ${peers[i]}`)
+
+      await this.postTransaction(transaction, peers[i])
+    }
+  }
+
+  async connect (network) {
+    if (this.server) {
+      logger.info(`Server is already configured as "${this.server}"`)
+    }
+
+    if (this.network && this.network.name === network) {
+      logger.info(`Network is already configured as "${this.network.name}"`)
+    }
+
+    const configured = this.server && this.network && (this.network.name && this.network.name === network)
+
+    if (!configured) {
+      this.setNetwork(network)
+      this.setServer()
+
+      await this.findAvailablePeers()
+
+      try {
+        const response = await this.getFromNode('/api/loader/autoconfigure')
+
+        this.network.config = response.data.network
+      } catch (error) {
+        return this.connect(network)
+      }
+    }
+  }
+
+  async __getRandomPeer () {
+    await this.__loadRemotePeers()
+
+    return sample(this.network.peers)
+  }
+
+  async __loadRemotePeers () {
+    if (isUrl(this.network.peers)) {
+      const response = await axios.get(this.network.peers)
+
+      this.network.peers = response.data.map(peer => `${peer.ip}:${peer.port}`)
+    }
+  }
+
+  __filterPeers (peers) {
+    let filteredPeers = peers
+      .filter(peer => peer.status === 'OK')
+      .filter(peer => peer.ip !== '127.0.0.1')
+
+    filteredPeers = orderBy(filteredPeers, ['height', 'delay'], ['desc', 'asc'])
+
+    const networkHeight = filteredPeers[0].height
+
+    return {
+      networkHeight,
+      peers: filteredPeers
+        .filter(peer => Math.abs(peer.height - networkHeight) <= 10)
+        .map(peer => (`${peer.ip}:${peer.port}`))
+    }
+  }
+
+  async __selectResponsivePeer (peer) {
+    const reachable = await isReachable(peer)
+
+    if (!reachable) {
+      logger.warn(`${peer} is unresponsive. Choosing new peer.`)
+
+      const randomPeer = await this.__getRandomPeer()
+
+      return this.__selectResponsivePeer(randomPeer)
+    }
+
+    return peer
+  }
+}
+
+module.exports = new Network()
+module.exports.logger = logger

--- a/lib/utils/output.js
+++ b/lib/utils/output.js
@@ -1,0 +1,59 @@
+'use strict'
+const Table = require('ascii-table')
+const logger = require('../services/logger')
+const chalk = require('chalk')
+const ARKUnits = 100000000
+
+class Output {
+    
+  setFormat(format){
+    switch (format) {
+      case "table":
+        this.format="table"
+        break
+      case "json":
+        this.format="json"
+        break
+      default:
+        throw new Error("Unknown output format")
+      }
+      return this.format;
+  }
+    
+  setCurrencySymbol(symbol){
+    this.symbol = symbol
+  }
+
+  showOutput(data){
+    if(typeof(this.format) !== 'undefined' && this.format === 'table') {
+      this.__showTable(data)      
+      return    
+    }
+        
+    // default to JSON output
+    let formattedData = JSON.stringify(data)
+    console.log(formattedData)
+    return
+  }
+    
+  showError(error){
+    if(typeof(this.format) !== 'undefined' && this.format === 'table') {
+      logger.error(error)      
+      return    
+    }
+    
+    // default to JSON output
+    let errorOutput = {
+      'success': false,
+      'error': error
+    }
+    console.log(chalk.red(JSON.stringify(errorOutput)))
+    return
+  }
+  
+  __showTable(data){
+    // TODO implement ASCII Table output
+    console.log("Hello World")
+  }
+}
+module.exports = new Output()

--- a/lib/utils/output.js
+++ b/lib/utils/output.js
@@ -32,7 +32,7 @@ class Output {
         
     // default to JSON output
     let formattedData = JSON.stringify(data)
-    console.log(formattedData)
+    console.log(chalk.blue(formattedData))
     return
   }
     
@@ -51,9 +51,35 @@ class Output {
     return
   }
   
-  __showTable(data){
-    // TODO implement ASCII Table output
-    console.log("Hello World")
+  setTitle(title){
+    this.title = title
   }
+  
+  __showTable(data){
+    let title = typeof(this.title) !== 'undefined' ? this.title : "ARK CLI"
+    let table = new Table(title)
+    
+    if(data.hasOwnProperty('balance')) {
+        data.balance = this.__formatBalance(data.balance);
+    }
+    
+    if(data.hasOwnProperty('unconfirmedBalance')) {
+        data.unconfirmedBalance = this.__formatBalance(data.unconfirmedBalance);
+    }
+    
+    for(let item in data) {
+        if (data[item] && data[item].length) {
+            table.addRow(item, data[item]);
+        }
+    }
+    
+    console.log(chalk.blue(table.toString()))
+  }
+  
+  __formatBalance(amount) {
+    let balance = amount / ARKUnits;
+    let symbol = typeof(this.symbol) !== 'undefined' ? `${this.symbol} ` : ''
+    return `${symbol}${balance}`;
+  } 
 }
 module.exports = new Output()

--- a/package.json
+++ b/package.json
@@ -29,7 +29,13 @@
     "figlet": "^1.2.0",
     "ledgerco": "github:ledgerhq/ledger-node-js-api#6cde5978b9d0a4922f0d33520b16cc2184559ebc",
     "lodash": "^4.17.10",
-    "ora": "^1.1.0"
+    "ora": "^1.1.0",
+    "axios": "^0.18.0",
+    "is-reachable": "^2.4.0",
+    "is-url": "^1.2.4",
+    "joi": "^13.2.0",
+    "pino": "^4.16.1",
+    "ascii-table": "^0.0.9"
   },
   "devDependencies": {
     "depcheck": "^0.6.9",


### PR DESCRIPTION
Implements the method to retrieve the wallet status for an address.

cli wallet <address> [options]
Options:
    -n, --network <network>  Connect to network: [mainnet|devnet] (default: mainnet)
    -c, --node <node>            Connect directly to node <node>.
    -f, --format <format>        Specify how to format the output [json|table] (default: json)
    -v, --verbose                    Show verbose logging.
    -h, --help                           output usage information

Added /lib/config/network.js /lib/services/logger.js|network.js from ARK-JSON-RPC git,
I have applied 1 change to networks.js (module.export of logger, so we can surpress logging when the option --verbose is not active)

TODO: The table output format method has not yet been implemented