### PR TITLE
 feature: implementation of network stats method

### DIFF
--- a/lib/commands/network/stats.js
+++ b/lib/commands/network/stats.js
@@ -82,12 +82,32 @@ module.exports = async (cmd) => {
         reject(error)
       })
     }))
+
+    let delegatesCount
+    commands.push(new Promise((resolve, reject) => {
+      network.getFromNode('/api/delegates/count')
+      .then((results) => {
+        // Validate response
+        if (!results.data.hasOwnProperty('success') || !results.data.success) {
+          let errorMsg = results.data.hasOwnProperty('error') && results.data.error
+            ? results.data.error : 'Failed to retrieve network delegates count from node.'
+            resolve()
+          reject(new Error(errorMsg))
+        }
+        delegatesCount = results.data.count
+        resolve()
+      })
+      .catch(error => {
+        reject(error)
+      })
+    }))
     await Promise.all(commands)
 
     // Prepare and show output
     for (let item in fees) {
       status[item] = fees[item]
     }
+    status['delegates count'] = delegatesCount
 
     output.setTitle(`ARK ${net} stats`)
     output.setCurrencySymbol(network.network.config.symbol)

--- a/lib/commands/network/stats.js
+++ b/lib/commands/network/stats.js
@@ -1,7 +1,99 @@
 'use strict'
 
-const chalk = require('chalk')
+const network = require('../../services/network')
+const output = require('../../utils/output')
+const networks = require('../../config/networks')
 
-module.exports = () => {
-  console.log(chalk.blue('Hello World!'))
+/**
+ * @dev Show network stats
+ * @param {object} cmd A JSON object containing the options for this query (network, node, format, verbose).
+ */
+module.exports = async (cmd) => {
+  let net = cmd.network ? cmd.network : 'mainnet'
+  let node = cmd.node ? cmd.node : null
+  let format = cmd.format ? cmd.format : 'json'
+
+  // Surpres logging if not --verbose
+  if (!cmd.verbose) {
+    network.logger.info = () => { }
+    network.logger.warn = () => { }
+    network.logger.error = (err) => {
+      output.showError(err)
+    }
+  }
+
+  try {
+    output.setFormat(format)
+
+    // connect to the network
+    if (!networks[net]) {
+      throw new Error(`Unknown network: ${net}`)
+    }
+
+    await network.setNetwork(net)
+
+    if (node) {
+      await network.setServer(node)
+      // The network.connect method skips network config when a server and network have been defined already
+      const response = await network.getFromNode('/api/loader/autoconfigure')
+      network.network.config = response.data.network
+    }
+    await network.connect(net)
+
+    // Retrieve network stats
+    let status
+    let commands = []
+    commands.push(new Promise((resolve, reject) => {
+      network.getFromNode('/api/blocks/getStatus')
+      .then((results) => {
+        // Validate response
+        if (!results.data.hasOwnProperty('success') || !results.data.success) {
+          let errorMsg = results.data.hasOwnProperty('error') && results.data.error
+            ? results.data.error : 'Failed to retrieve network status from node.'
+            resolve()
+          reject(new Error(errorMsg))
+        }
+        status = results.data
+        delete status.success
+        delete status.fee // will be set by fees.send
+        resolve()
+      })
+      .catch(error => {
+        reject(error)
+      })
+    }))
+
+    let fees
+    commands.push(new Promise((resolve, reject) => {
+      network.getFromNode('/api/blocks/getFees')
+      .then((results) => {
+        // Validate response
+        if (!results.data.hasOwnProperty('success') || !results.data.success) {
+          let errorMsg = results.data.hasOwnProperty('error') && results.data.error
+            ? results.data.error : 'Failed to retrieve network fees from node.'
+            resolve()
+          reject(new Error(errorMsg))
+        }
+        fees = results.data
+        delete fees.success
+        resolve()
+      })
+      .catch(error => {
+        reject(error)
+      })
+    }))
+    await Promise.all(commands)
+
+    // Prepare and show output
+    for (let item in fees) {
+      status[item] = fees[item]
+    }
+
+    output.setTitle(`ARK ${net} stats`)
+    output.setCurrencySymbol(network.network.config.symbol)
+    output.showOutput(status)
+  } catch (error) {
+    output.showError(error.message)
+    process.exitCode = 1
+  }
 }

--- a/lib/utils/output.js
+++ b/lib/utils/output.js
@@ -53,25 +53,32 @@ class Output {
   }
 
   __showTable (data) {
-    let title = typeof (this.title) !== 'undefined' ? this.title : 'ARK CLI'
+    let title = typeof (this.title) !== 'undefined' ? this.title : 'ARK-JavaScript-CLI'
     let table = new Table(title)
 
-    if (data.hasOwnProperty('balance')) {
-        data.balance = this.__formatBalance(data.balance);
-    }
-
-    if (data.hasOwnProperty('unconfirmedBalance')) {
-        data.unconfirmedBalance = this.__formatBalance(data.unconfirmedBalance);
-    }
-
-    if (data.hasOwnProperty('amount')) {
-        data.amount = this.__formatBalance(data.amount);
+    if (data.hasOwnProperty('fees')) {
+      for (let item in data.fees) {
+        data[`${item} fee`] = this.__formatBalance(data.fees[item])
+      }
+      delete data.fees
     }
 
     for (let item in data) {
-        if (data[item] && data[item].length) {
-            table.addRow(item, data[item]);
-        }
+      // format anything that represents a value
+      switch (item) {
+        case 'balance':
+        case 'unconfirmedBalance':
+        case 'amount':
+        case 'supply':
+        case 'reward':
+          data[item] = this.__formatBalance(data[item])
+          break
+        default:
+      }
+      data[item] = data[item].toString()
+      if (data[item] && data[item].length) {
+        table.addRow(item, data[item])
+      }
     }
 
     console.log(chalk.blue(table.toString()))
@@ -80,7 +87,7 @@ class Output {
   __formatBalance (amount) {
     let balance = amount / ARKUnits;
     let symbol = typeof (this.symbol) !== 'undefined' ? `${this.symbol} ` : ''
-    return `${symbol}${balance}`;
+    return `${symbol}${balance}`
   }
 }
 module.exports = new Output()


### PR DESCRIPTION
feature: implementation of network stats method.

I deviated from the networks stats as shown in the current cli because a) I am not sure if these are very meaningful and b) a graph output wouldn't make much sense in a true CLI where output can be used as the next script's input. In case we really want the graphs back, then I suggest we refactor this PR to become a command called "network" andI'll re-create stats as the graph outputting method as was.