### PR TITLE
fix: poll all peers for their status in parrallel

### DIFF
--- a/lib/services/network.js
+++ b/lib/services/network.js
@@ -66,14 +66,24 @@ class Network {
         peers = peers.slice(0, 10)
       }
 
+      let commands = []
       let responsivePeers = []
       for (let i = 0; i < peers.length; i++) {
-        const response = await this.getFromNode('/peer/status', {}, peers[i])
-
-        if (Math.abs(response.data.height - networkHeight) <= 10) {
-          responsivePeers.push(peers[i])
-        }
+        // Poll all peers parralelly: this saves yuuuge time
+        commands.push(new Promise((resolve, reject) => {
+          this.getFromNode('/peer/status', {}, peers[i])
+          .then((response) => {
+            if (Math.abs(response.data.height - networkHeight) <= 10) {
+              responsivePeers.push(peers[i])
+            }
+            resolve()
+          })
+          .catch(error => {
+            reject(error)
+          })
+        }))
       }
+      await Promise.all(commands)
 
       this.network.peers = responsivePeers
     } catch (error) {


### PR DESCRIPTION
Polling each peer sequencially is very time costly. So now we poll them all at the same time. 