### PR TITLE
Fix: Update public API  port

### DIFF
--- a/lib/services/network.js
+++ b/lib/services/network.js
@@ -141,8 +141,8 @@ class Network {
   async __loadRemotePeers () {
     if (isUrl(this.network.peers)) {
       const response = await axios.get(this.network.peers)
-
-      this.network.peers = response.data.map(peer => `${peer.ip}:${peer.port}`)
+      const publicAPIPort = 4003
+      this.network.peers = response.data.map(peer => `${peer.ip}:${publicAPIPort}`)
     }
   }
 


### PR DESCRIPTION
Fix breaking issue after seed peers updated to v2:

The seeds in the peers repository have port 4002/4001 (as they should),but we need to use the public API port 4003 to even be able to retrieve responsive peers from the network.