### PR TITLE
fix: make getFromNode() method query p2p port if api port returns 404

### DIFF
--- a/lib/services/network.js
+++ b/lib/services/network.js
@@ -35,20 +35,50 @@ class Network {
     }
 
     peer = await this.__selectResponsivePeer(peer || this.server)
-
+    let uri
     if (!url.startsWith('http')) {
-      url = `http://${peer}${url}`
+      uri = `http://${peer}${url}`
     }
 
     try {
-      logger.info(`Sending request on "${this.network.name}" to "${url}"`)
+      logger.info(`Sending request on "${this.network.name}" to "${uri}"`)
 
-      return axios.get(url, {
+      return axios.get(uri, {
         params,
         headers: {
           nethash,
           version: '2.0.0',
           port: 1
+        }
+      }).catch(err => {
+        if (err.message === 'Request failed with status code 404') {
+          // We are trying on the wrong API version
+          let peerParts = peer.split(':')
+          let port = peerParts[peerParts.length - 1]
+          switch (port) {
+            case '4003':
+              if (this.network.name === 'devnet') {
+                peerParts[peerParts.length - 1] = '4002' // Set devnet port
+              } else if (this.network.name === 'mainnet') {
+                peerParts[peerParts.length - 1] = '4001' // Set mainnet port
+              }
+              break;
+            case '4001':
+            case '4002':
+            default:
+              peerParts[peerParts.length - 1] = '4003' // Set the public API port
+          }
+          peer = peerParts.join(':')
+          uri = `http://${peer}${url}`
+          logger.info(`Sending request on "${this.network.name}" to "${uri}"`)
+          return axios.get(uri, {
+            params,
+            headers: {
+              nethash,
+              version: '2.0.0',
+              port: 1
+            }
+          })
         }
       })
     } catch (error) {
@@ -151,8 +181,13 @@ class Network {
   async __loadRemotePeers () {
     if (isUrl(this.network.peers)) {
       const response = await axios.get(this.network.peers)
-      const publicAPIPort = 4003
-      this.network.peers = response.data.map(peer => `${peer.ip}:${publicAPIPort}`)
+
+      if (this.network.name === 'devnet') {
+        const publicAPIPort = '4003'
+        this.network.peers = response.data.map(peer => `${peer.ip}:${publicAPIPort}`)
+      } else {
+        this.network.peers = response.data.map(peer => `${peer.ip}:${peer.port}`)
+      }
     }
   }
 


### PR DESCRIPTION
In the current situation where V1 and V2 nodes are mixed (and later on when devnet is V2 and mainnet still v1) some queries need to be executed on p2p port (4001/4002) and others on API port 4003.
the getFromNode() method will now try again when receiving a 404 error: switching between api and p2p ports.
