### PR TITLE
fix: hardening peer selections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,32 @@
 language: node_js
 
 node_js:
-  - node
   - 9
+  - 8
+  
+addons:
+  apt:
+    packages:
+      - build-essential
+      - git
+      - gcc-4.8
+      - g++-4.8
+      - libusb-1.0-0
+      - libusb-1.0-0-dev
+      - libudev1
+      - libudev-dev
+
+install:
+  - export CXX=g++-4.8
+
+before_script:
+  - npm install -g node-gyp
+  - npm install node-hid --build-from-source
+  - npm install
 
 script:
-  - yarn test
+  - npm test
 
-cache: yarn
+cache:
+  directories:
+    - node_modules

--- a/lib/services/network.js
+++ b/lib/services/network.js
@@ -17,7 +17,7 @@ class Network {
 
       return this.network
     } catch (err) {
-      logger.error(err.message)
+      logger.error(err)
       return false
     }
   }
@@ -88,7 +88,7 @@ class Network {
         }
       })
     } catch (error) {
-      logger.error(error.message)
+      logger.error(error)
     }
   }
 
@@ -97,19 +97,24 @@ class Network {
       const response = await this.getFromNode('/peer/list')
 
       let { networkHeight, peers } = this.__filterPeers(response.data.peers)
-
+      
       if (process.env.NODE_ENV === 'test') {
         peers = peers.slice(0, 10)
       }
 
       let commands = []
       let responsivePeers = []
+      let queue = 0
       for (let i = 0; i < peers.length; i++) {
         // Poll all peers parralelly: this saves yuuuge time
-        commands.push(new Promise((resolve, reject) => {
+        if (typeof (commands[queue]) === 'undefined') {
+          commands[queue] = []
+        }
+
+        commands[queue].push(new Promise((resolve, reject) => {
           this.getFromNode('/peer/status', {}, peers[i])
           .then((response) => {
-            if (Math.abs(response.data.height - networkHeight) <= 10) {
+            if (response.data.hasOwnProperty('success') && response.data.success === true) {
               responsivePeers.push(peers[i])
             }
             resolve()
@@ -118,13 +123,29 @@ class Network {
             reject(error)
           })
         }))
+
+        let queueLength = commands[queue].length
+        if (queueLength % 10 === 0) {
+          // Next block
+          queue++
+        }
       }
-      await Promise.all(commands)
+
+      for (let i = 0; i < commands.length; i++) {
+        await Promise.all(commands[i])
+      }
+
+      if (responsivePeers.length === 0) {
+        throw new Error('Could not update responsive peers')
+      }
 
       this.network.peers = responsivePeers
+      logger.info(`Updated responsive peers: ${responsivePeers.length} near height: ${networkHeight}`)
+      return responsivePeers.length
     } catch (error) {
-      logger.error(error.message)
+      logger.error(error)
     }
+    return false
   }
 
   async postTransaction (transaction, peer) {
@@ -204,10 +225,28 @@ class Network {
     let filteredPeers = peers
       .filter(peer => peer.status === 'OK')
       .filter(peer => peer.ip !== '127.0.0.1')
+      .filter(peer => Number.isSafeInteger(parseInt(peer.height, 10)))
 
     filteredPeers = orderBy(filteredPeers, ['height', 'delay'], ['desc', 'asc'])
 
-    const networkHeight = filteredPeers[0].height
+    let networkHeight = 0
+    let mostCommonHeightCount = 0
+    let heightOccurances = []
+
+    for (let item in filteredPeers) {
+      let height = filteredPeers[item].height
+
+      if (typeof (heightOccurances[height]) === 'undefined') {
+        heightOccurances[height] = 1
+      } else {
+        heightOccurances[height]++
+      }
+
+      if (mostCommonHeightCount < heightOccurances[height]) {
+        mostCommonHeightCount = heightOccurances[height]
+        networkHeight = height
+      }
+    }
 
     return {
       networkHeight,


### PR DESCRIPTION
Discovery of peers as currently is has 2 problems:

- I created the parallel peer discovery with limiting the amount of parallel streams: this PR fixes that.
- The selected peers are filtered by height, where the peer with the max height is considered best. Any attacker could just bring a network of nodes in the air that broadcast a hard-coded height 999999999. This PR solves that by selecting peers based on the most common broadcasted height +- a deviation.
