### PR TITLE
v2: commands message sign and verify updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
   - npm install -g node-gyp
   - npm install node-hid --build-from-source
   - npm install
+  - yarn add @arkecosystem/crypto
 
 script:
   - npm test

--- a/__tests__/utils/crypto.test.js
+++ b/__tests__/utils/crypto.test.js
@@ -1,0 +1,50 @@
+'use strict'
+const crypto = require('../../lib/utils/crypto.js')
+
+describe('crypto', () => {
+  it('should be an object', () => {
+    expect(crypto).toBeObject()
+  })
+})
+
+describe('crypto.sign', () => {
+  it('should be a function', () => {
+    expect(crypto.sign).toBeFunction()
+  })
+
+  it('should correctly sign a message', () => {
+    const msg = 'Point. Click. Blockchain.'
+    const passphrase = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
+    const networkVersion = 30 // devnet
+    const publicKey = '03e734aba4bc673b5c106bd90dfb7fe19a2faf32aa0a4a40d62ddda9d41ab239e4'
+    const address = 'DEHXB5HdRjYSuH8PHtJ3H6vquViHFVRQak'
+    const signature = '304402202a50bc620e7f97a2e1d416ddca79988bbb8232f4428a9fddd5a187dd3c11462b022078355bf458fbd9aa1842bf119afa3f686027fcc724d9bb73b66b234e0d51066e'
+
+    const result = crypto.sign(msg, passphrase, networkVersion)
+    expect(result).toBeObject()
+    expect(result).toContainKeys(['publicKey', 'address', 'signature', 'message'])
+    expect(result.publicKey).toBe(publicKey)
+    expect(result.address).toBe(address)
+    expect(result.signature).toBe(signature)
+    expect(result.message).toBe(msg)
+  })
+})
+
+describe('crypto.verify', () => {
+  it('should be a function', () => {
+    expect(crypto.verify).toBeFunction()
+  })
+
+  it('should correctly verify a message', () => {
+    const msg = 'Point. Click. Blockchain.'
+    const signature = '304402202a50bc620e7f97a2e1d416ddca79988bbb8232f4428a9fddd5a187dd3c11462b022078355bf458fbd9aa1842bf119afa3f686027fcc724d9bb73b66b234e0d51066e'
+    const publicKey = '03e734aba4bc673b5c106bd90dfb7fe19a2faf32aa0a4a40d62ddda9d41ab239e4'
+
+    const result = crypto.verify(msg, signature, publicKey)
+    expect(result).toBeTrue()
+
+    const badMsg = 'Will not verify'
+    const badResult = crypto.verify(badMsg, signature, publicKey)
+    expect(badResult).toBeFalse()
+  })
+})

--- a/__tests__/utils/crypto.test.js
+++ b/__tests__/utils/crypto.test.js
@@ -13,20 +13,20 @@ describe('crypto.sign', () => {
   })
 
   it('should correctly sign a message', () => {
-    const msg = 'Point. Click. Blockchain.'
-    const passphrase = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
+    const message = 'Hello World'
+    const passphrase = 'this is a top secret passphrase'
     const networkVersion = 30 // devnet
-    const publicKey = '03e734aba4bc673b5c106bd90dfb7fe19a2faf32aa0a4a40d62ddda9d41ab239e4'
-    const address = 'DEHXB5HdRjYSuH8PHtJ3H6vquViHFVRQak'
-    const signature = '304402202a50bc620e7f97a2e1d416ddca79988bbb8232f4428a9fddd5a187dd3c11462b022078355bf458fbd9aa1842bf119afa3f686027fcc724d9bb73b66b234e0d51066e'
+    const publicKey = '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
+    const address = 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib'
+    const signature = '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8'
 
-    const result = crypto.sign(msg, passphrase, networkVersion)
+    const result = crypto.sign(message, passphrase, networkVersion)
     expect(result).toBeObject()
     expect(result).toContainKeys(['publicKey', 'address', 'signature', 'message'])
     expect(result.publicKey).toBe(publicKey)
     expect(result.address).toBe(address)
     expect(result.signature).toBe(signature)
-    expect(result.message).toBe(msg)
+    expect(result.message).toBe(message)
   })
 })
 
@@ -36,11 +36,11 @@ describe('crypto.verify', () => {
   })
 
   it('should correctly verify a message', () => {
-    const msg = 'Point. Click. Blockchain.'
-    const signature = '304402202a50bc620e7f97a2e1d416ddca79988bbb8232f4428a9fddd5a187dd3c11462b022078355bf458fbd9aa1842bf119afa3f686027fcc724d9bb73b66b234e0d51066e'
-    const publicKey = '03e734aba4bc673b5c106bd90dfb7fe19a2faf32aa0a4a40d62ddda9d41ab239e4'
+    const message = 'Hello World'
+    const signature = '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8'
+    const publicKey = '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
 
-    const result = crypto.verify(msg, signature, publicKey)
+    const result = crypto.verify(message, signature, publicKey)
     expect(result).toBeTrue()
 
     const badMsg = 'Will not verify'

--- a/lib/commands/message/sign.js
+++ b/lib/commands/message/sign.js
@@ -1,8 +1,6 @@
 'use strict'
-
 const Joi = require('joi')
-const arkjs = require('arkjs')
-const crypto = require('crypto')
+const crypto = require('../../utils/crypto')
 const network = require('../../services/network')
 const output = require('../../utils/output')
 const input = require('../../utils/input')
@@ -18,7 +16,7 @@ const schema = {
  * @param {object} cmd A JSON object containing the options for this query (network, node, format, verbose).
  */
 module.exports = async (msg, cmd) => {
-  let net = cmd.network ? cmd.network : 'mainnet'
+  let net = cmd.network ? cmd.network : 'devnet'
   let format = cmd.format ? cmd.format : 'json'
   let passphrase = cmd.passphrase ? cmd.passphrase : false
 
@@ -57,21 +55,10 @@ module.exports = async (msg, cmd) => {
       throw new Error(`Unknown network: ${net}`)
     }
     await network.setNetwork(net)
-    arkjs.crypto.setNetworkVersion(network.network.version)
 
     // Sign the Message
-    let hash = crypto.createHash('sha256');
-    hash = hash.update(Buffer.from(msg, 'utf-8')).digest()
-    const publicKey = arkjs.crypto.getKeys(passphrase).publicKey
-    const address = arkjs.crypto.getAddress(arkjs.crypto.getKeys(passphrase).publicKey)
-    const signature = arkjs.crypto.getKeys(passphrase).sign(hash).toDER().toString('hex')
+    const result = crypto.sign(msg, passphrase, network.network.version)
 
-    const result = {
-      publicKey,
-      address,
-      signature,
-      message: msg
-    }
     output.setTitle('ARK Sign message')
     output.showOutput(result)
   } catch (error) {

--- a/lib/commands/message/verify.js
+++ b/lib/commands/message/verify.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const arkjs = require('arkjs')
-const crypto = require('crypto')
+const crypto = require('../../utils/crypto')
 const network = require('../../services/network')
 const output = require('../../utils/output')
 const networks = require('../../config/networks')
@@ -50,18 +49,9 @@ module.exports = async (msg, publicKey, signature, cmd) => {
     if (!networks[net]) {
       throw new Error(`Unknown network: ${net}`)
     }
-    await network.setNetwork(net)
-    arkjs.crypto.setNetworkVersion(network.network.version)
 
     // Verify the Message
-    let hash = crypto.createHash('sha256');
-    hash = hash.update(Buffer.from(msg, 'utf-8')).digest()
-
-    signature = Buffer.from(signature, 'hex');
-    publicKey = Buffer.from(publicKey, 'hex');
-    const ecpair = arkjs.ECPair.fromPublicKeyBuffer(publicKey);
-    const ecsignature = arkjs.ECSignature.fromDER(signature);
-    const verification = ecpair.verify(hash, ecsignature);
+    const verification = crypto.verify(msg, signature, publicKey)
 
     if (!verification) {
       throw new Error('Message could not be verified with this key and signature.')

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -1,0 +1,38 @@
+'use strict'
+const arkecosystem = require('@arkecosystem/crypto')
+const arkUtils = arkecosystem.utils
+const ECPair = arkecosystem.ECPair
+const ECSignature = arkecosystem.ECSignature
+const crypto = arkecosystem.crypto
+
+class Crypto {
+  sign (msg, passphrase, networkVersion) {
+    let hash = arkUtils.hash256(Buffer.from(msg, 'utf-8'))
+    const publicKey = crypto.getKeys(passphrase).publicKey
+    const address = crypto.getAddress(publicKey, networkVersion)
+    const signature = crypto.getKeys(passphrase).sign(hash).toDER().toString('hex')
+
+    const result = {
+      publicKey,
+      address,
+      signature,
+      message: msg
+    }
+
+    return result
+  }
+
+  verify (msg, signature, publicKey) {
+    let hash = arkUtils.hash256(Buffer.from(msg, 'utf-8'))
+
+    signature = Buffer.from(signature, 'hex')
+    publicKey = Buffer.from(publicKey, 'hex')
+    const ecpair = ECPair.fromPublicKeyBuffer(publicKey)
+    const ecsignature = ECSignature.fromDER(signature)
+    const verification = ecpair.verify(hash, ecsignature)
+
+    return verification
+  }
+}
+
+module.exports = new Crypto()

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -3,30 +3,28 @@ const arkecosystem = require('@arkecosystem/crypto')
 const arkUtils = arkecosystem.utils
 const ECPair = arkecosystem.ECPair
 const ECSignature = arkecosystem.ECSignature
-const crypto = arkecosystem.crypto
+const arkCrypto = arkecosystem.crypto
 
 class Crypto {
-  sign (msg, passphrase, networkVersion) {
-    let hash = arkUtils.hash256(Buffer.from(msg, 'utf-8'))
-    const publicKey = crypto.getKeys(passphrase).publicKey
-    const address = crypto.getAddress(publicKey, networkVersion)
-    const signature = crypto.getKeys(passphrase).sign(hash).toDER().toString('hex')
+  sign (message, passphrase, networkVersion) {
+    const hash = arkUtils.sha256(Buffer.from(message, 'utf-8'))
+    const publicKey = arkCrypto.getKeys(passphrase).publicKey
+    const address = arkCrypto.getAddress(publicKey, networkVersion)
+    const signature = arkCrypto.getKeys(passphrase).sign(hash).toDER().toString('hex')
 
     const result = {
       publicKey,
       address,
       signature,
-      message: msg
+      message
     }
-
     return result
   }
 
-  verify (msg, signature, publicKey) {
-    let hash = arkUtils.hash256(Buffer.from(msg, 'utf-8'))
-
+  verify (message, signature, publicKey) {
     signature = Buffer.from(signature, 'hex')
     publicKey = Buffer.from(publicKey, 'hex')
+    const hash = arkUtils.sha256(Buffer.from(message, 'utf-8'))
     const ecpair = ECPair.fromPublicKeyBuffer(publicKey)
     const ecsignature = ECSignature.fromDER(signature)
     const verification = ecpair.verify(hash, ecsignature)

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "depcheck": "depcheck ./"
   },
   "dependencies": {
+    "@arkecosystem/crypto": "^0.1.2",
     "arkjs": "github:arkecosystem/ark-js#master",
     "ascii-table": "^0.0.9",
     "axios": "^0.18.0",
     "bip39": "^2.5.0",
+    "browserify-bignum": "^1.3.0-2",
     "bs58check": "^2.1.2",
     "chalk": "^2.4.1",
     "figlet": "^1.2.0",


### PR DESCRIPTION
This PR updates the message sign and verify commands to use the V2 ARK - Crypto package instead of arkjs.