### PR TITLE
 v2: update ledger to use v2 libraries

### DIFF
--- a/__tests__/utils/crypto.test.js
+++ b/__tests__/utils/crypto.test.js
@@ -68,6 +68,21 @@ describe('crypto.getAddress', () => {
   })
 })
 
+describe('crypto.getAddressFromPublicKey', () => {
+  it('should be a function', () => {
+    expect(crypto.getAddressFromPublicKey).toBeFunction()
+  })
+
+  it('should correctly generate an address from a publicKey', () => {
+    const networkVersion = 30 // devnet
+    const publicKey = '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
+    const address = 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib'
+
+    const result = crypto.getAddressFromPublicKey(publicKey, networkVersion)
+    expect(result).toBe(address)
+  })
+})
+
 describe('crypto.registerDelegate', () => {
   it('should be a function', () => {
     expect(crypto.registerDelegate).toBeFunction()
@@ -151,5 +166,23 @@ describe('crypto.getTransactionId', () => {
     const transaction = crypto.createTransaction(recepient, amount, vendorField, passphrase, secondSecret, fee)
     const transactionId = crypto.getTransactionId(transaction)
     expect(transactionId).toBe(transaction.id)
+  })
+})
+
+describe('crypto.getTransactionBytesHex', () => {
+  it('should be a function', () => {
+    expect(crypto.getTransactionBytesHex).toBeFunction()
+  })
+
+  it('should return a transaction in HEX', () => {
+    const recepient = 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib'
+    const amount = 100000000
+    const vendorField = 'Hello World'
+    const passphrase = 'this is a top secret passphrase'
+    const secondSecret = null
+    const fee = 1000
+    const transaction = crypto.createTransaction(recepient, amount, vendorField, passphrase, secondSecret, fee)
+    const result = crypto.getTransactionBytesHex(transaction)
+    expect(result).toBeString()
   })
 })

--- a/lib/commands/wallet/ledger.js
+++ b/lib/commands/wallet/ledger.js
@@ -44,9 +44,6 @@ module.exports = async (cmd) => {
 
     if (node) {
       await network.setServer(node)
-      // The network.connect method skips network config when a server and network have been defined already
-      const response = await network.getFromNode('/api/loader/autoconfigure')
-      network.network.config = response.data.network
     }
     await network.connect(net)
 

--- a/lib/commands/wallet/send.js
+++ b/lib/commands/wallet/send.js
@@ -133,6 +133,7 @@ module.exports = async (amount, recepient, cmd) => {
 
       delete transaction.signature
       delete transaction.id
+      delete transaction.timestamp
 
       // Select which wallet to use
       let i = await input.getLedgerWallet(wallets)

--- a/lib/commands/wallet/send.js
+++ b/lib/commands/wallet/send.js
@@ -133,7 +133,6 @@ module.exports = async (amount, recepient, cmd) => {
 
       delete transaction.signature
       delete transaction.id
-      delete transaction.timestamp
 
       // Select which wallet to use
       let i = await input.getLedgerWallet(wallets)

--- a/lib/ledger/LedgerArk.js
+++ b/lib/ledger/LedgerArk.js
@@ -39,12 +39,12 @@ class LedgerArk {
     const pathLength = 4 * splitPath.length + 1
     const apdus = []
     let data1, data2, p1, response
-
+console.log(`BEFORE PATH`)
     path = Buffer.alloc(pathLength - 1)
     splitPath.forEach((element, index) => {
       path.writeUInt32BE(element, 4 * index)
     })
-
+console.log(`AFTER PATH`)
     if (rawTx.length > 255 - pathLength) {
       data1 = rawTx.slice(0, 255 - pathLength)
       data2 = rawTx.slice(255 - pathLength)

--- a/lib/ledger/LedgerArk.js
+++ b/lib/ledger/LedgerArk.js
@@ -32,19 +32,20 @@ class LedgerArk {
   }
 
   async signTransaction (path, rawTxHex) {
+console.log(`BEFORE PATH`)
     const splitPath = utils.splitPath(path)
+console.log(`AFTER PATH`)
     const rawTx = Buffer.from(rawTxHex, 'hex')
     const data1HeaderLength = Buffer.alloc(2)
     const data2HeaderLength = Buffer.alloc(1)
     const pathLength = 4 * splitPath.length + 1
     const apdus = []
     let data1, data2, p1, response
-console.log(`BEFORE PATH`)
     path = Buffer.alloc(pathLength - 1)
     splitPath.forEach((element, index) => {
       path.writeUInt32BE(element, 4 * index)
     })
-console.log(`AFTER PATH`)
+
     if (rawTx.length > 255 - pathLength) {
       data1 = rawTx.slice(0, 255 - pathLength)
       data2 = rawTx.slice(255 - pathLength)

--- a/lib/ledger/LedgerArk.js
+++ b/lib/ledger/LedgerArk.js
@@ -32,9 +32,7 @@ class LedgerArk {
   }
 
   async signTransaction (path, rawTxHex) {
-console.log(`BEFORE PATH`)
     const splitPath = utils.splitPath(path)
-console.log(`AFTER PATH`)
     const rawTx = Buffer.from(rawTxHex, 'hex')
     const data1HeaderLength = Buffer.alloc(2)
     const data2HeaderLength = Buffer.alloc(1)

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -104,8 +104,11 @@ class Ledger {
     }
 
     try {
-      account = await this.network.getFromNode(`/api/v2/wallets/${address}`)
-      return Promise.resolve(account.data.data)
+      const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
+      if(result.data !== null) {
+        account = result.data.data
+      }
+      return Promise.resolve(account)
     } catch (error) {
       console.log(error)
       return Promise.reject(error)

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -69,8 +69,6 @@ class Ledger {
         const address = crypto.getAddressFromPublicKey(publicKey, this.networkVersion)
         let account = {
           address,
-          unconfirmedBalance: 0,
-          balance: 0,
           publicKey,
           'Status': 'Address unknown to the network'
         }
@@ -105,10 +103,10 @@ class Ledger {
 
     try {
       const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
-      if(result === null) {
-        throw new Error('unused account')
+      if(result !== null) {
+        return Promise.resolve(result.data.data)
       }
-      return Promise.resolve(result.data.data)
+      return Promise.resolve()
     } catch (error) {
       console.log(error)
       return Promise.reject(error)

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -1,12 +1,11 @@
-const arkjs = require('arkjs')
-// const bip39 = require('bip39')
 const logger = require('../services/logger')
+const crypto = require('../utils/crypto')
 
 class Ledger {
   setNetwork (network) {
     if (network.hasOwnProperty('network') && network.network.hasOwnProperty('version')) {
       this.network = network
-      arkjs.crypto.setNetworkVersion(this.network.network.version)
+      this.networkVersion = this.network.network.version
       return this.network
     }
     throw new Error('not a valid network')
@@ -67,7 +66,7 @@ class Ledger {
         i++
       } catch (error) {
         // this is the first unused account on this ledger,and it's not known to the network
-        const address = arkjs.crypto.getAddress(publicKey)
+        const address = crypto.getAddressFromPublicKey(publicKey, this.networkVersion)
         let account = {
           address,
           unconfirmedBalance: 0,
@@ -86,7 +85,7 @@ class Ledger {
   async signTransaction (path, transaction) {
     logger.warn('Please confirm your transaction on your Ledger device!')
     try {
-      let transactionHex = arkjs.crypto.getBytes(transaction, true, true).toString('hex')
+      let transactionHex = crypto.getTransactionBytesHex(transaction)
       let result = await this.LedgerArk.signTransaction(path, transactionHex)
       return result.signature
     } catch (error) {
@@ -98,15 +97,15 @@ class Ledger {
   // async signMessage (path, message) {}
 
   async __getAccount (publicKey) {
-    const address = arkjs.crypto.getAddress(publicKey)
+    const address = crypto.getAddressFromPublicKey(publicKey, this.networkVersion)
     let account = {
       address,
       publicKey
     }
 
     try {
-      account = await this.network.getFromNode(`/api/accounts?address=${account.address}`)
-      return Promise.resolve(account.data.account)
+      account = await this.network.getFromNode(`/api/v2/wallets/${address}`)
+      return Promise.resolve(account.data.data)
     } catch (error) {
       console.log(error)
       return Promise.reject(error)

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -83,8 +83,9 @@ class Ledger {
   async signTransaction (path, transaction) {
     logger.warn('Please confirm your transaction on your Ledger device!')
     try {
+logger.info(`BEFORE TX HEX`)
       let transactionHex = crypto.getTransactionBytesHex(transaction)
-logger.info(transaction)
+logger.info(`AFTER TX HEX`)
       let result = await this.LedgerArk.signTransaction(path, transactionHex)
       return result.signature
     } catch (error) {

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -84,6 +84,7 @@ class Ledger {
     logger.warn('Please confirm your transaction on your Ledger device!')
     try {
       let transactionHex = crypto.getTransactionBytesHex(transaction)
+logger.info(transaction)
       let result = await this.LedgerArk.signTransaction(path, transactionHex)
       return result.signature
     } catch (error) {

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -87,6 +87,7 @@ class Ledger {
       let result = await this.LedgerArk.signTransaction(path, transactionHex)
       return result.signature
     } catch (error) {
+  logger.error(`TESTING LEDGER: ${path} || ${transaction}`)
       return Promise.reject(error)
     }
   }

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -98,7 +98,7 @@ class Ledger {
     const address = crypto.getAddressFromPublicKey(publicKey, this.networkVersion)
     try {
       const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
-      if(result !== null) {
+      if (result !== null) {
         const account = result.data.data
         if (account.publicKey === null) {
           account.publicKey = publicKey

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -105,10 +105,10 @@ class Ledger {
 
     try {
       const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
-      if(result !== null) {
-        account = result.data.data
+      if(result === null) {
+        throw new Error('unused account')
       }
-      return Promise.resolve(account)
+      return Promise.resolve(result.data.data)
     } catch (error) {
       console.log(error)
       return Promise.reject(error)

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -105,7 +105,7 @@ class Ledger {
 
     try {
       const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
-      if(result.data !== null) {
+      if(result !== null) {
         account = result.data.data
       }
       return Promise.resolve(account)

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -83,9 +83,7 @@ class Ledger {
   async signTransaction (path, transaction) {
     logger.warn('Please confirm your transaction on your Ledger device!')
     try {
-logger.info(`BEFORE TX HEX`)
       let transactionHex = crypto.getTransactionBytesHex(transaction)
-logger.info(`AFTER TX HEX`)
       let result = await this.LedgerArk.signTransaction(path, transactionHex)
       return result.signature
     } catch (error) {
@@ -101,7 +99,11 @@ logger.info(`AFTER TX HEX`)
     try {
       const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
       if(result !== null) {
-        return Promise.resolve(result.data.data)
+        const account = result.data.data
+        if (account.publicKey === null) {
+          account.publicKey = publicKey
+        }
+        return Promise.resolve(account)
       }
       return Promise.resolve()
     } catch (error) {

--- a/lib/ledger/ledger.js
+++ b/lib/ledger/ledger.js
@@ -87,7 +87,6 @@ class Ledger {
       let result = await this.LedgerArk.signTransaction(path, transactionHex)
       return result.signature
     } catch (error) {
-  logger.error(`TESTING LEDGER: ${path} || ${transaction}`)
       return Promise.reject(error)
     }
   }
@@ -97,11 +96,6 @@ class Ledger {
 
   async __getAccount (publicKey) {
     const address = crypto.getAddressFromPublicKey(publicKey, this.networkVersion)
-    let account = {
-      address,
-      publicKey
-    }
-
     try {
       const result = await this.network.getFromNode(`/api/v2/wallets/${address}`)
       if(result !== null) {

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -20,6 +20,7 @@ class Crypto {
   }
 
   getTransactionBytesHex (transaction) {
+    console.log(`Transaction: ${JSON.stringify(transaction)}`)
     return arkecosystem.crypto.getBytes(transaction, true, true).toString('hex')
   }
 

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -14,6 +14,15 @@ class Crypto {
     return {address, publicKey}
   }
 
+  getAddressFromPublicKey (publicKey, networkVersion) {
+    const address = arkCrypto.getAddress(publicKey, networkVersion)
+    return address
+  }
+
+  getTransactionBytesHex (transaction) {
+    return arkecosystem.crypto.getBytes(transaction, true, true).toString('hex')
+  }
+
   sign (message, passphrase, networkVersion) {
     const {address, publicKey} = this.getAddress(passphrase, networkVersion)
     const hash = arkUtils.sha256(Buffer.from(message, 'utf-8'))

--- a/package.json
+++ b/package.json
@@ -25,11 +25,8 @@
   },
   "dependencies": {
     "@arkecosystem/crypto": "^0.1.2",
-    "arkjs": "github:arkecosystem/ark-js#master",
     "ascii-table": "^0.0.9",
     "axios": "^0.18.0",
-    "bip39": "^2.5.0",
-    "browserify-bignum": "^1.3.0-2",
     "bs58check": "^2.1.2",
     "chalk": "^2.4.1",
     "figlet": "^1.2.0",
@@ -40,8 +37,7 @@
     "lodash": "^4.17.10",
     "ora": "^1.1.0",
     "pino": "^4.16.1",
-    "prompt": "^1.0.0",
-    "workerpool": "^2.3.0"
+    "prompt": "^1.0.0"
   },
   "devDependencies": {
     "depcheck": "^0.6.9",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lodash": "^4.17.10",
     "ora": "^1.1.0",
     "pino": "^4.16.1",
-    "prompt": "^1.0.0"
+    "prompt": "^1.0.0",
+    "workerpool": "^2.3.1"
   },
   "devDependencies": {
     "depcheck": "^0.6.9",


### PR DESCRIPTION
This PR updates the Ledger device methods to use the V2 libraries.

Should be removing the final usage of arkjs. 
