### PR TITLE
Vanity - keyword in starting

### DIFF
--- a/vanity.js
+++ b/vanity.js
@@ -8,7 +8,7 @@ process.on("message", function(message){
     var address = "";
     var passphrase;
     var count = 0;
-    while(address.toLowerCase().indexOf(message.string) == -1){
+    while(address.toLowerCase().indexOf(message.string) != 1 ){
       passphrase = bip39.generateMnemonic();
       address = arkjs.crypto.getAddress(arkjs.crypto.getKeys(passphrase).publicKey);
       if(++count == 10){

--- a/vanity.js
+++ b/vanity.js
@@ -9,7 +9,7 @@ process.on("message", function(message){
     var passphrase;
     var count = 0;
 
-    while(address.toLowerCase().indexOf(message.string) != 1 ){
+    while(address.toLowerCase().indexOf(message.string) !== 1 ){
       passphrase = bip39.generateMnemonic();
       address = arkjs.crypto.getAddress(arkjs.crypto.getKeys(passphrase).publicKey);
       if(++count === 10){


### PR DESCRIPTION
Vanity Addresses normally have desired string in the starting. Keyword in middle doesn't mean much to the user.

Now, desired keyword will start from second place only. However, this may increase time required to generate the vanity address. But it will be worth it. ;D

Please see https://docs.ark.io/docs/contributing for details before opening your pull request.
