### PR TITLE
fix: CircleCI missing deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install required packages
           command: |
             sudo apt-get update
-            sudo apt-get -t jessie-backports install libudev-dev libusb-1.0-0-dev
+            sudo apt-get libudev-dev libusb-1.0-0-dev
       - restore_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install required packages
           command: |
             sudo apt-get update
-            sudo apt-get libudev-dev libusb-1.0-0-dev
+            sudo apt-get install libudev-dev libusb-1.0-0-dev
       - restore_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test-node-9:
     working_directory: ~/javascript-cli
     docker:
-      - image: circleci/node:9.11-browsers
+      - image: circleci/node:9.11.1-stretch-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Recently `jessie-backports` has moved sources to archive.debian.org which might be causing CircleCI to fail.